### PR TITLE
feat: add CLI Version to default output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+const { readFileSync } = require("fs")
+
 let CLI_KEYS = {};
 let CLI_ARGS = [];
 
@@ -95,6 +98,7 @@ njs2 upgrade [version] [version-number]`);
     break;
 
   default:
+    console.log('CLI Version: ' + JSON.parse(readFileSync('./package.json')).version)
     console.log(`
 njs2 project <project-name>
 njs2 endpoint <endpoint-name>


### PR DESCRIPTION
Running `njs2` will now output:
```
CLI Version: 2.0.0-beta.1

njs2 project <project-name>
njs2 endpoint <endpoint-name>
njs2 run serverless
njs2 run express
njs2 run nodemon
njs2 plugin-local <plugin-name> <plugin-project-path>
njs2 plugin <plugin-name>
njs2 plugin uninstall <plugin-name>
njs2 plugin compile
njs2 plugin install <plugin-name>
njs2 library <folder-name> <filename> <options : [sql,mongo]>
njs2 upgrade [version] [version-number]
```

Instead of:
```

njs2 project <project-name>
njs2 endpoint <endpoint-name>
njs2 run serverless
njs2 run express
njs2 run nodemon
njs2 plugin-local <plugin-name> <plugin-project-path>
njs2 plugin <plugin-name>
njs2 plugin uninstall <plugin-name>
njs2 plugin compile
njs2 plugin install <plugin-name>
njs2 library <folder-name> <filename> <options : [sql,mongo]>
njs2 upgrade [version] [version-number]
```

This way we can know the version of the CLI we're running on.